### PR TITLE
Update both Info and Stat to recent HAProxy versions

### DIFF
--- a/info.go
+++ b/info.go
@@ -11,12 +11,16 @@ type Info struct {
 	Name                       string `kv:"Name"`
 	Version                    string `kv:"Version"`
 	ReleaseDate                string `kv:"Release_date"`
+	Nbthread                   uint64 `kv:"Nbthread"`
 	Nbproc                     uint64 `kv:"Nbproc"`
 	ProcessNum                 uint64 `kv:"Process_num"`
 	Pid                        uint64 `kv:"Pid"`
 	Uptime                     string `kv:"Uptime"`
 	UptimeSec                  uint64 `kv:"Uptime_sec"`
 	MemMaxMB                   uint64 `kv:"Memmax_MB"`
+	PoolAllocMB                uint64 `kv:"PoolAlloc_MB"`
+	PoolUsedMB                 uint64 `kv:"PoolUsed_MB"`
+	PoolFailed                 uint64 `kv:"PoolFailed"`
 	UlimitN                    uint64 `kv:"Ulimit-n"`
 	Maxsock                    uint64 `kv:"Maxsock"`
 	Maxconn                    uint64 `kv:"Maxconn"`
@@ -49,13 +53,24 @@ type Info struct {
 	CompressBpsIn              uint64 `kv:"CompressBpsIn"`
 	CompressBpsOut             uint64 `kv:"CompressBpsOut"`
 	CompressBpsRateLim         uint64 `kv:"CompressBpsRateLim"`
-	ZlibMemUsage               uint64 `kv:"ZlibMemUsage"`
-	MaxZlibMemUsage            uint64 `kv:"MaxZlibMemUsage"`
-	Tasks                      uint64 `kv:"Tasks"`
-	RunQueue                   uint64 `kv:"Run_queue"`
-	IdlePct                    uint64 `kv:"Idle_pct"`
-	Node                       string `kv:"node"`
-	Description                string `kv:"description"`
+	//ZlibMemUsage               uint64 `kv:"ZlibMemUsage"`
+	//MaxZlibMemUsage            uint64 `kv:"MaxZlibMemUsage"`
+	Tasks               uint64 `kv:"Tasks"`
+	RunQueue            uint64 `kv:"Run_queue"`
+	IdlePct             uint64 `kv:"Idle_pct"`
+	Node                string `kv:"node"`
+	Stopping            uint64 `kv:"Stopping"`
+	Jobs                uint64 `kv:"Jobs"`
+	UnstoppableJobs     uint64 `kv:"Unstoppable Jobs"`
+	Listeners           uint64 `kv:"Listeners"`
+	ActivePeers         uint64 `kv:"ActivePeers"`
+	ConnectedPeers      uint64 `kv:"ConnectedPeers"`
+	DroppedLogs         uint64 `kv:"DroppedLogs"`
+	BusyPolling         uint64 `kv:"BusyPolling"`
+	FailedResolutions   uint64 `kv:"FailedResolutions"`
+	TotalBytesOut       uint64 `kv:"TotalBytesOut"`
+	BytesOutRate        uint64 `kv:"BytesOutRate"`
+	DebugCommandsIssued uint64 `kv:"DebugCommandsIssued"`
 }
 
 // Equivalent to HAProxy "show info" command.

--- a/stat.go
+++ b/stat.go
@@ -71,6 +71,43 @@ type Stat struct {
 	Ctime         uint64 `csv:"ctime"`
 	Rtime         uint64 `csv:"rtime"`
 	Ttime         uint64 `csv:"ttime"`
+	AgentStatus   uint64 `csv:"agent_status"`
+	AgentCode     uint64 `csv:"agent_code"`
+	AgentDuration uint64 `csv:"agent_duration"`
+	CheckDesc     uint64 `csv:"check_desc"`
+	AgentDesc     uint64 `csv:"agent_desc"`
+	CheckRise     uint64 `csv:"check_rise"`
+	CheckFall     uint64 `csv:"check_fall"`
+	CheckHealth   uint64 `csv:"check_health"`
+	AgentRise     uint64 `csv:"agent_rise"`
+	AgentFall     uint64 `csv:"agent_fall"`
+	AgentHealth   uint64 `csv:"agent_health"`
+	Addr          string `csv:"addr"`
+	Cookie        uint64 `csv:"cookie"`
+	Mode          string `csv:"mode"`
+	Algo          string `csv:"algo"`
+	ConnRate      uint64 `csv:"conn_rate"`
+	ConnRateMax   uint64 `csv:"conn_rate_max"`
+	ConnTot       uint64 `csv:"conn_tot"`
+	Intercepted   uint64 `csv:"intercepted"`
+	Dcon          uint64 `csv:"dcon"`
+	Dses          uint64 `csv:"dses"`
+	Wrew          uint64 `csv:"wrew"`
+	Connect       uint64 `csv:"connect"`
+	Reuse         uint64 `csv:"reuse"`
+	CacheLookups  uint64 `csv:"cache_lookups"`
+	CacheHits     uint64 `csv:"cache_hits"`
+	SrvIcur       uint64 `csv:"srv_icur"`
+	SrcIlim       uint64 `csv:"src_ilim"`
+	QtimeMax      uint64 `csv:"qtime_max"`
+	CtimeMax      uint64 `csv:"ctime_max"`
+	RtimeMax      uint64 `csv:"rtime_max"`
+	TtimeMax      uint64 `csv:"ttime_max"`
+	Eint          uint64 `csv:"eint"`
+	IdleConnCur   uint64 `csv:"idle_conn_cur"`
+	SafeConnCur   uint64 `csv:"safe_conn_cur"`
+	UsedConnCur   uint64 `csv:"used_conn_cur"`
+	NeedConnEst   uint64 `csv:"need_conn_est"`
 }
 
 // Equivalent to HAProxy "show stat" command.


### PR DESCRIPTION
This patch makes both Info and Stat structure to reflect
recent (version 2.2+) HAProxy metrics.

Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>