### PR TITLE
Added deadline timeout for socket operations (avoid deadlocks)

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -2,13 +2,18 @@ package haproxy_test
 
 import (
 	"fmt"
+	"github.com/vponomarev/go-haproxy"
+)
 
-	"github.com/bcicen/go-haproxy"
+const (
+	HAPROXY_SOCKET_ADDR = "unix:///var/run/haproxy.sock"
 )
 
 func ExampleHAProxyClient_Stats() {
 	client := &haproxy.HAProxyClient{
-		Addr: "unix:///var/run/haproxy.sock",
+		Addr:      HAPROXY_SOCKET_ADDR,
+		Timeout:   30,
+		TimeoutOp: 5,
 	}
 	stats, err := client.Stats()
 	if err != nil {
@@ -27,7 +32,7 @@ func ExampleHAProxyClient_Stats() {
 
 func ExampleHAProxyClient_Info() {
 	client := &haproxy.HAProxyClient{
-		Addr: "unix:///var/run/haproxy.sock",
+		Addr: HAPROXY_SOCKET_ADDR,
 	}
 	info, err := client.Info()
 	if err != nil {
@@ -36,12 +41,12 @@ func ExampleHAProxyClient_Info() {
 	}
 	fmt.Printf("%s version %s\n", info.Name, info.Version)
 	// Output:
-	//HAProxy version 1.6.3
+	//HAProxy version 2.8.1
 }
 
 func ExampleHAProxyClient_RunCommand() {
 	client := &haproxy.HAProxyClient{
-		Addr: "unix:///var/run/haproxy.sock",
+		Addr: HAPROXY_SOCKET_ADDR,
 	}
 	result, err := client.RunCommand("show info")
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bcicen/go-haproxy
+module github.com/vponomarev/go-haproxy
 
 go 1.16
 

--- a/info.go
+++ b/info.go
@@ -3,7 +3,7 @@ package haproxy
 import (
 	"fmt"
 
-	"github.com/bcicen/go-haproxy/kvcodec"
+	"github.com/vponomarev/go-haproxy/kvcodec"
 )
 
 // Response from HAProxy "show info" command.


### PR DESCRIPTION
Current implementation will be blocked forever in case if haproxy (or someone else, opened this socket) will not generate any answer and will not close socket.

So, the fix is:
1. Presented new parameter TimeoutOp for operation timeout (separate from Timeout, used for connection timeout), now it will be possible to set Timeout = 10 (10 sec for connection) and TimeoutOp = 2 (2 sec for processing request).
2. Added SetDeadline for connection

I tested with fake haproxy running by:
`socat - UNIX-LISTEN:./var/run/haproxy.sock`

Old implementation was blocked, new implementation returned after timeout:
`read unix ->/var/run/haproxy.sock: i/o timeout`